### PR TITLE
fix: resolve ENOENT when spawning openclaw CLI on Windows

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import { registerGatewayMethods } from "./src/gateway";
 import { SessionManager } from "./src/session-manager";
 import { NotificationRouter } from "./src/notifications";
 import { setSessionManager, setNotificationRouter, setPluginConfig, pluginConfig } from "./src/shared";
-import { execFile } from "child_process";
+import { execFileOpenclaw } from "./src/spawn-helper";
 
 // Plugin register function - called by OpenClaw when loading the plugin
 export function register(api: any) {
@@ -161,7 +161,7 @@ export function register(api: any) {
         }
         cliArgs.push("--target", target, "-m", text);
 
-        execFile("openclaw", cliArgs, { timeout: 15_000 }, (err, stdout, stderr) => {
+        execFileOpenclaw(cliArgs, { timeout: 15_000 }, (err, stdout, stderr) => {
           if (err) {
             console.error(`[claude-code] sendMessage CLI ERROR: ${err.message}`);
             if (stderr) console.error(`[claude-code] sendMessage CLI STDERR: ${stderr}`);

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn } from "child_process";
+import { spawnOpenclaw, execFileOpenclaw } from "./spawn-helper";
 import { Session } from "./session";
 import { generateSessionName } from "./shared";
 import type { NotificationRouter } from "./notifications";
@@ -338,7 +338,7 @@ export class SessionManager {
     }
 
     const deliverArgs = this.buildDeliverArgs(session.originChannel);
-    const child = spawn("openclaw", ["agent", "--agent", agentId, "--message", eventText, ...deliverArgs], {
+    const child = spawnOpenclaw( ["agent", "--agent", agentId, "--message", eventText, ...deliverArgs], {
       detached: true,
       stdio: "ignore",
     });
@@ -380,7 +380,7 @@ export class SessionManager {
    */
   private fireSystemEventWithRetry(eventText: string, label: string, sessionId: string): void {
     const args = ["system", "event", "--text", eventText, "--mode", "now"];
-    execFile("openclaw", args, { timeout: WAKE_CLI_TIMEOUT_MS }, (err, _stdout, stderr) => {
+    execFileOpenclaw( args, { timeout: WAKE_CLI_TIMEOUT_MS }, (err, _stdout, stderr) => {
       if (err) {
         console.error(`[SessionManager] System event failed for ${label} session=${sessionId}: ${err.message}`);
         if (stderr) console.error(`[SessionManager] stderr: ${stderr}`);
@@ -388,7 +388,7 @@ export class SessionManager {
         console.warn(`[SessionManager] Scheduling retry in ${WAKE_RETRY_DELAY_MS}ms for ${label} session=${sessionId}`);
         const timer = setTimeout(() => {
           this.pendingRetryTimers.delete(timer);
-          execFile("openclaw", args, { timeout: WAKE_CLI_TIMEOUT_MS }, (retryErr, _retryStdout, retryStderr) => {
+          execFileOpenclaw( args, { timeout: WAKE_CLI_TIMEOUT_MS }, (retryErr, _retryStdout, retryStderr) => {
             if (retryErr) {
               console.error(`[SessionManager] System event retry also failed for ${label} session=${sessionId}: ${retryErr.message}`);
               if (retryStderr) console.error(`[SessionManager] retry stderr: ${retryStderr}`);

--- a/src/spawn-helper.ts
+++ b/src/spawn-helper.ts
@@ -1,0 +1,59 @@
+﻿/**
+ * Cross-platform helper for spawning the `openclaw` CLI.
+ *
+ * On Windows, npm global installs produce `.cmd` / `.bat` wrappers instead of
+ * native executables.  Node's `child_process.execFile` and `spawn` bypass the
+ * shell by default, so they cannot resolve `.cmd` files - resulting in ENOENT.
+ *
+ * Adding `{ shell: true }` fixes ENOENT but introduces two new problems:
+ *   1. `cmd.exe` may pick up the extensionless POSIX shim before `.cmd`,
+ *      causing a "node.exe is not recognized" error.
+ *   2. Arguments containing spaces / emoji are re-parsed by `cmd.exe`,
+ *      breaking the `-m <message>` parameter.
+ *
+ * This module resolves the issue by locating the actual `openclaw.mjs` entry
+ * point and invoking it directly via `process.execPath` (the current Node
+ * binary), completely bypassing `.cmd` wrappers and shell quoting issues.
+ *
+ * On non-Windows platforms the standard `"openclaw"` binary name is used
+ * unchanged.
+ */
+
+import { execFile, spawn, type SpawnOptions, type ExecFileOptions } from "child_process";
+import { join } from "path";
+import { existsSync } from "fs";
+
+/** Resolved once at module load time. `null` on non-Windows or if not found. */
+const openclawMjs: string | null = (() => {
+  if (process.platform !== "win32") return null;
+  const appData = process.env.APPDATA;
+  if (!appData) return null;
+  const candidate = join(appData, "npm", "node_modules", "openclaw", "openclaw.mjs");
+  return existsSync(candidate) ? candidate : null;
+})();
+
+/**
+ * Spawn `openclaw <args>` as a detached background process.
+ * Drop-in replacement for `spawn("openclaw", args, opts)`.
+ */
+export function spawnOpenclaw(args: string[], opts: SpawnOptions) {
+  if (openclawMjs) {
+    return spawn(process.execPath, [openclawMjs, ...args], opts);
+  }
+  return spawn("openclaw", args, opts);
+}
+
+/**
+ * Execute `openclaw <args>` and collect output.
+ * Drop-in replacement for `execFile("openclaw", args, opts, cb)`.
+ */
+export function execFileOpenclaw(
+  args: string[],
+  opts: ExecFileOptions,
+  cb: (error: Error | null, stdout: string, stderr: string) => void,
+) {
+  if (openclawMjs) {
+    return execFile(process.execPath, [openclawMjs, ...args], opts, cb);
+  }
+  return execFile("openclaw", args, opts, cb);
+}


### PR DESCRIPTION
## Problem

On Windows, npm global installs produce `.cmd` / `.bat` wrappers instead of native executables. Node.js `child_process.execFile` and `spawn` bypass the shell by default, so they cannot resolve `.cmd` files, resulting in `ENOENT`.

### Error observed
```
[claude-code] sendMessage CLI ERROR: spawn openclaw ENOENT
[openclaw] Uncaught exception: Error: spawn openclaw ENOENT
```

### Root cause chain

1. `execFile('openclaw', ...)` / `spawn('openclaw', ...)` - **ENOENT** (no native exe, only .cmd wrapper)
2. Adding `{ shell: true }` fixes ENOENT but `cmd.exe` picks up the extensionless POSIX shim before `.cmd`, causing **node.exe is not recognized**
3. Using `'openclaw.cmd'` + `{ shell: true }` resolves the binary but `cmd.exe` re-parses arguments containing spaces/emoji, **breaking the** `-m <message>` **parameter**

## Solution

Added `src/spawn-helper.ts` that:
- On Windows: locates `openclaw.mjs` via `%APPDATA%/npm/node_modules/openclaw/openclaw.mjs` and invokes it directly with `process.execPath` (the current Node binary)
- On non-Windows: uses `'openclaw'` unchanged (zero behavior change)

This completely bypasses `.cmd` wrappers and shell quoting issues.

### Files changed
- `src/spawn-helper.ts` - New cross-platform helper module
- `src/session-manager.ts` - Use `spawnOpenclaw` / `execFileOpenclaw` instead of raw `spawn` / `execFile`
- `index.ts` - Use `execFileOpenclaw` in sendMessage callback

### Testing
Verified on Windows 11 with npm global install. Discord notifications and agent wake both work correctly with emoji and multi-word messages.