### PR TITLE
feat: add agentEnv config for per-agent environment variables

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -64,6 +64,16 @@
         "type": "boolean",
         "default": false,
         "description": "Skip ALL pre-launch safety guards (autonomy skill, heartbeat, HEARTBEAT.md, agentChannels). Use only for development/testing."
+      },
+      "agentEnv": {
+        "type": "object",
+        "description": "Per-agent environment variables keyed by working directory prefix. Longest prefix match wins. Matched env vars are merged on top of process.env for that session. Example: { \"/home/user/project-a\": { \"GH_TOKEN\": \"ghp_xxx\" } }",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
       }
     }
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -60,6 +60,7 @@ export class Session {
   private readonly systemPrompt?: string;
   private readonly allowedTools?: string[];
   private readonly permissionMode: PermissionMode;
+  private readonly env?: Record<string, string>;
 
   // Resume/fork config (Task 16)
   readonly resumeSessionId?: string;
@@ -141,6 +142,7 @@ export class Session {
     this.systemPrompt = config.systemPrompt;
     this.allowedTools = config.allowedTools;
     this.permissionMode = config.permissionMode ?? pluginConfig.permissionMode ?? "bypassPermissions";
+    this.env = config.env;
     this.originChannel = config.originChannel;
     this.originAgentId = config.originAgentId;
     this.resumeSessionId = config.resumeSessionId;
@@ -164,6 +166,7 @@ export class Session {
         includePartialMessages: true,
         abortController: this.abortController,
         ...(this.systemPrompt ? { systemPrompt: this.systemPrompt } : {}),
+        ...(this.env ? { env: this.env } : {}),
       };
 
       // Resume support (Task 16): pass resume + forkSession to SDK

--- a/src/tools/claude-launch.ts
+++ b/src/tools/claude-launch.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { Type } from "@sinclair/typebox";
-import { sessionManager, pluginConfig, resolveOriginChannel, resolveAgentChannel, resolveAgentId } from "../shared";
+import { sessionManager, pluginConfig, resolveOriginChannel, resolveAgentChannel, resolveAgentId, resolveAgentEnv } from "../shared";
 import type { OpenClawPluginToolContext } from "../types";
 
 export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
@@ -398,6 +398,9 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
           }
         } // end skipSafetyChecks
 
+        // Resolve per-agent environment variables from agentEnv config
+        const agentEnv = resolveAgentEnv(workdir);
+
         const session = sessionManager.spawn({
           prompt: params.prompt,
           name: params.name,
@@ -412,6 +415,7 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
           permissionMode: params.permission_mode,
           originChannel,
           originAgentId: ctx.agentId || undefined,
+          env: agentEnv,
         });
 
         const promptSummary =

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,9 @@ export interface SessionConfig {
 
   // Multi-turn support (Task 15)
   multiTurn?: boolean;  // If true, use AsyncIterable prompt for multi-turn conversations
+
+  // Per-agent environment variables
+  env?: Record<string, string>;
 }
 
 export interface ClaudeSession {
@@ -116,4 +119,17 @@ export interface PluginConfig {
    * Default: false.
    */
   skipSafetyChecks?: boolean;
+
+  /**
+   * Per-agent environment variables, keyed by working directory prefix.
+   * When a session is launched, the plugin matches the session's workdir
+   * against these prefixes (longest match wins) and merges the matching
+   * env vars into the session's environment, overriding process.env.
+   *
+   * Example: {
+   *   "/home/user/teramino": { "GH_TOKEN": "ghp_teramino_token" },
+   *   "/home/user/other-project": { "GH_TOKEN": "ghp_other_token" }
+   * }
+   */
+  agentEnv?: Record<string, Record<string, string>>;
 }


### PR DESCRIPTION
## Summary

Adds a new `agentEnv` plugin config option that enables per-agent environment variable isolation in multi-agent setups.

In a multi-agent OpenClaw deployment, all agents share the same container and `process.env`. This means environment variables like `GH_TOKEN` are identical for every Claude Code session regardless of which agent spawned it. This is a problem when different agents need different service accounts (e.g., different GitHub identities per project).

## How it works

`agentEnv` maps working directory prefixes to environment variable overrides:

```json
{
  "agentEnv": {
    "/home/user/project-a": {
      "GH_TOKEN": "ghp_project_a_token"
    },
    "/home/user/project-b": {
      "GH_TOKEN": "ghp_project_b_token",
      "AWS_PROFILE": "project-b"
    }
  }
}
```

When `claude_launch` is called:
1. The session's `workdir` is matched against `agentEnv` keys using longest-prefix-match (same logic as `agentChannels`)
2. If a match is found, the matched env vars are merged on top of `process.env`
3. The merged env is passed to the Claude Agent SDK `query()` call via its `env` option
4. If no match is found, the session inherits `process.env` as before (no behavior change)

## Changes

- **`types.ts`** — Added `agentEnv` to `PluginConfig`, `env` to `SessionConfig`
- **`shared.ts`** — Added `resolveAgentEnv()` (mirrors `resolveAgentChannel` pattern)
- **`session.ts`** — Accepts `env`, passes to SDK `query()` options
- **`tools/claude-launch.ts`** — Resolves `agentEnv` by workdir before spawning
- **`openclaw.plugin.json`** — Added `agentEnv` to config schema

5 files changed, 59 insertions(+), 1 deletion(-)