### PR TITLE
fix: resolve env vars in agentChannels keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betrue/openclaw-claude-code-plugin",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -19,6 +19,22 @@ export let pluginConfig: PluginConfig = {
 };
 
 export function setPluginConfig(config: Partial<PluginConfig>): void {
+  // Expand environment variables in agentChannels keys.
+  // The gateway resolves env vars in config values but not in object keys,
+  // so patterns like "${HOME}/projects" need to be expanded here.
+  let agentChannels = config.agentChannels;
+  if (agentChannels) {
+    const expanded: Record<string, string> = {};
+    for (const [key, value] of Object.entries(agentChannels)) {
+      const resolvedKey = key.replace(/\$\{(\w+)\}/g, (match, varName) => {
+        const envValue = process.env[varName];
+        return envValue !== undefined ? envValue : match;
+      });
+      expanded[resolvedKey] = value;
+    }
+    agentChannels = expanded;
+  }
+
   pluginConfig = {
     maxSessions: config.maxSessions ?? 5,
     defaultBudgetUsd: config.defaultBudgetUsd ?? 5,
@@ -27,7 +43,7 @@ export function setPluginConfig(config: Partial<PluginConfig>): void {
     idleTimeoutMinutes: config.idleTimeoutMinutes ?? 30,
     maxPersistedSessions: config.maxPersistedSessions ?? 50,
     fallbackChannel: config.fallbackChannel,
-    agentChannels: config.agentChannels,
+    agentChannels,
     maxAutoResponds: config.maxAutoResponds ?? 10,
   };
 }


### PR DESCRIPTION
## Problem

The OpenClaw gateway resolves `${VAR}` patterns in config **values** but not in object **keys**. This causes `resolveAgentChannel()` lookups to fail when `agentChannels` keys contain `${HOME}` or other env vars — the plugin receives `${HOME}/clawd` as a key but tries to match against `/Users/selim/clawd`.

## Fix

Expand env vars in `agentChannels` keys during `setPluginConfig()` using `process.env`. If an env var is not defined, the original `${VAR}` pattern is kept as-is.

## Testing

- Verified `claude_launch` works with `${HOME}`-based agentChannels config
- No changes to values (already resolved by gateway)