### PR TITLE
fix: agent isolation, notification routing, session scoping

### DIFF
--- a/src/commands/claude-resume.ts
+++ b/src/commands/claude-resume.ts
@@ -91,6 +91,7 @@ export function registerClaudeResumeCommand(api: any): void {
           resumeSessionId: claudeSessionId,
           forkSession: fork,
           originChannel: resolveOriginChannel(ctx),
+          deliverChannel: persisted?.deliverChannel,
         });
 
         const promptSummary =

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -239,9 +239,10 @@ export class NotificationRouter {
           `   Use claude_fg to check on it, or claude_kill to stop it.`,
         ].join("\n");
 
-        // Try to notify the origin channel if available
-        if (session.originChannel) {
-          this.sendMessage(session.originChannel, msg);
+        // Try to notify the deliver channel (launching agent's channel), falling back to origin
+        const notifyChannel = session.deliverChannel ?? session.originChannel;
+        if (notifyChannel) {
+          this.sendMessage(notifyChannel, msg);
         }
       }
     }

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -47,6 +47,7 @@ interface PersistedSessionInfo {
   costUsd: number;
   originAgentId?: string;
   originChannel?: string;
+  deliverChannel?: string;
 }
 
 /** Debounce interval for waiting-for-input events (ms) */
@@ -214,6 +215,7 @@ export class SessionManager {
       costUsd: session.costUsd,
       originAgentId: session.originAgentId,
       originChannel: session.originChannel,
+      deliverChannel: session.deliverChannel,
     };
 
     // Store by internal ID
@@ -337,7 +339,7 @@ export class SessionManager {
       return;
     }
 
-    const deliverArgs = this.buildDeliverArgs(session.originChannel);
+    const deliverArgs = this.buildDeliverArgs(session.deliverChannel ?? session.originChannel);
     const child = spawn("openclaw", ["agent", "--agent", agentId, "--message", eventText, ...deliverArgs], {
       detached: true,
       stdio: "ignore",
@@ -369,7 +371,7 @@ export class SessionManager {
       return;
     }
 
-    const channel = session.originChannel || "unknown";
+    const channel = session.deliverChannel ?? session.originChannel ?? "unknown";
     console.log(`[SessionManager] Delivering ${label} to Telegram for session=${session.id} via channel=${channel}`);
     this.notificationRouter.emitToChannel(channel, notificationText);
   }
@@ -519,9 +521,9 @@ export class SessionManager {
    * Resolve a Claude session ID from our internal ID, name, or Claude session ID.
    * Looks in both active sessions and persisted (completed/GC'd) sessions.
    */
-  resolveClaudeSessionId(ref: string): string | undefined {
+  resolveClaudeSessionId(ref: string, agentId?: string): string | undefined {
     // 1. Check active sessions
-    const active = this.resolve(ref);
+    const active = this.resolve(ref, agentId);
     if (active?.claudeSessionId) return active.claudeSessionId;
 
     // 2. Check persisted sessions
@@ -559,17 +561,26 @@ export class SessionManager {
 
   /**
    * Resolve a session by ID or name.
+   * When agentId is provided, only returns the session if it was launched by that agent.
+   * When agentId is undefined (commands, gateway), no ownership filtering is applied.
    */
-  resolve(idOrName: string): Session | undefined {
+  resolve(idOrName: string, agentId?: string): Session | undefined {
     // Try ID first (exact match)
-    const byId = this.sessions.get(idOrName);
-    if (byId) return byId;
+    let session = this.sessions.get(idOrName);
 
     // Try name match
-    for (const session of this.sessions.values()) {
-      if (session.name === idOrName) return session;
+    if (!session) {
+      for (const s of this.sessions.values()) {
+        if (s.name === idOrName) { session = s; break; }
+      }
     }
-    return undefined;
+
+    if (!session) return undefined;
+
+    // Agent isolation: if agentId provided, enforce ownership
+    if (agentId && session.originAgentId !== agentId) return undefined;
+
+    return session;
   }
 
   get(id: string): Session | undefined {

--- a/src/session.ts
+++ b/src/session.ts
@@ -114,6 +114,9 @@ export class Session {
   // Origin channel -- the channel that launched this session (for background notifications)
   originChannel?: string;
 
+  // Deliver channel -- the agent's own channel for --deliver args in wakeAgent()
+  readonly deliverChannel?: string;
+
   // Origin agent ID -- the agent that launched this session (for targeted wake events)
   readonly originAgentId?: string;
 
@@ -142,6 +145,7 @@ export class Session {
     this.allowedTools = config.allowedTools;
     this.permissionMode = config.permissionMode ?? pluginConfig.permissionMode ?? "bypassPermissions";
     this.originChannel = config.originChannel;
+    this.deliverChannel = config.deliverChannel;
     this.originAgentId = config.originAgentId;
     this.resumeSessionId = config.resumeSessionId;
     this.forkSession = config.forkSession;

--- a/src/tools/claude-bg.ts
+++ b/src/tools/claude-bg.ts
@@ -48,7 +48,7 @@ export function makeClaudeBgTool(ctx?: OpenClawPluginToolContext) {
 
       // If a specific session is given, detach it
       if (params.session) {
-        const session = sessionManager.resolve(params.session);
+        const session = sessionManager.resolve(params.session, ctx?.agentId);
         if (!session) {
           return {
             content: [

--- a/src/tools/claude-fg.ts
+++ b/src/tools/claude-fg.ts
@@ -48,7 +48,7 @@ export function makeClaudeFgTool(ctx?: OpenClawPluginToolContext) {
         };
       }
 
-      const session = sessionManager.resolve(params.session);
+      const session = sessionManager.resolve(params.session, ctx?.agentId);
 
       if (!session) {
         return {

--- a/src/tools/claude-kill.ts
+++ b/src/tools/claude-kill.ts
@@ -2,7 +2,7 @@ import { Type } from "@sinclair/typebox";
 import { sessionManager } from "../shared";
 import type { OpenClawPluginToolContext } from "../types";
 
-export function makeClaudeKillTool(_ctx?: OpenClawPluginToolContext) {
+export function makeClaudeKillTool(ctx?: OpenClawPluginToolContext) {
   return {
     name: "claude_kill",
     description: "Terminate a running Claude Code session by name or ID.",
@@ -21,7 +21,7 @@ export function makeClaudeKillTool(_ctx?: OpenClawPluginToolContext) {
         };
       }
 
-      const session = sessionManager.resolve(params.session);
+      const session = sessionManager.resolve(params.session, ctx?.agentId);
 
       if (!session) {
         return {

--- a/src/tools/claude-launch.ts
+++ b/src/tools/claude-launch.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { Type } from "@sinclair/typebox";
-import { sessionManager, pluginConfig, resolveOriginChannel, resolveAgentChannel, resolveAgentId } from "../shared";
+import { sessionManager, pluginConfig, resolveAgentChannel, resolveAgentId } from "../shared";
 import type { OpenClawPluginToolContext } from "../types";
 
 export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
@@ -91,7 +91,7 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
         // Resolve resume_session_id: accept name, internal ID, or Claude UUID
         let resolvedResumeId = params.resume_session_id;
         if (resolvedResumeId) {
-          const resolved = sessionManager.resolveClaudeSessionId(resolvedResumeId);
+          const resolved = sessionManager.resolveClaudeSessionId(resolvedResumeId, ctx.agentId);
           if (!resolved) {
             return {
               content: [
@@ -105,39 +105,58 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
           resolvedResumeId = resolved;
         }
 
-        // Build channel from ctx if available.
-        // Priority: 1) ctx.messageChannel with injected accountId (if multi-segment)
-        //           2) resolveAgentChannel(ctx.workspaceDir) from agentChannels config
-        //           3) resolveAgentChannel(workdir) as secondary workspace lookup
-        //           4) ctx.messageChannel as-is (if it already has |)
-        let ctxChannel: string | undefined;
-        if (ctx.messageChannel && ctx.agentAccountId) {
-          const parts = ctx.messageChannel.split("|");
-          if (parts.length >= 2) {
-            ctxChannel = `${parts[0]}|${ctx.agentAccountId}|${parts.slice(1).join("|")}`;
-          }
-        }
-        // If messageChannel was bare (e.g. "telegram"), fall back to workspace-based lookup
-        if (!ctxChannel && ctx.workspaceDir) {
-          ctxChannel = resolveAgentChannel(ctx.workspaceDir);
-        }
-        if (!ctxChannel && ctx.messageChannel && ctx.messageChannel.includes("|")) {
-          ctxChannel = ctx.messageChannel;
+        // Build originChannel with fallback chain:
+        // 1) resolveAgentChannel(workdir)        — the SESSION's workdir (most specific)
+        // 2) resolveAgentChannel(ctx.workspaceDir) — the AGENT's workspace
+        // 3) ctx.messageChannel with injected accountId
+        // 4) ctx.messageChannel as-is (if it already has |)
+        // 5) pluginConfig.fallbackChannel
+        let originChannel: string | undefined;
+
+        // Tier 1: session workdir → agentChannels
+        originChannel = resolveAgentChannel(workdir);
+
+        // Tier 2: agent workspace → agentChannels
+        if (!originChannel && ctx.workspaceDir) {
+          originChannel = resolveAgentChannel(ctx.workspaceDir);
         }
 
-        // Resolve origin channel with fallback chain:
-        // 1. ctx-based channel (from above)
-        // 2. resolveAgentChannel(workdir) — workdir may differ from ctx.workspaceDir
-        // 3. resolveOriginChannel falls back to pluginConfig.fallbackChannel
-        let originChannel = resolveOriginChannel(
-          { id: _id },
-          ctxChannel || resolveAgentChannel(workdir),
-        );
-        if (originChannel === "unknown") {
-          const agentChannel = resolveAgentChannel(workdir);
-          if (agentChannel) {
-            originChannel = agentChannel;
+        // Tier 3: ctx.messageChannel with injected accountId
+        if (!originChannel && ctx.messageChannel && ctx.agentAccountId) {
+          const parts = ctx.messageChannel.split("|");
+          if (parts.length >= 2) {
+            originChannel = `${parts[0]}|${ctx.agentAccountId}|${parts.slice(1).join("|")}`;
           }
+        }
+
+        // Tier 4: ctx.messageChannel as-is (if multi-segment)
+        if (!originChannel && ctx.messageChannel && ctx.messageChannel.includes("|")) {
+          originChannel = ctx.messageChannel;
+        }
+
+        // Tier 5: pluginConfig.fallbackChannel
+        if (!originChannel) {
+          originChannel = pluginConfig.fallbackChannel ?? "unknown";
+        }
+
+        // Build deliverChannel: the AGENT's own channel for --deliver args in wakeAgent().
+        // This ensures the wake response is delivered back to the launching agent's workspace,
+        // not the session's workdir (which may differ).
+        let deliverChannel: string | undefined;
+        if (ctx.workspaceDir) {
+          deliverChannel = resolveAgentChannel(ctx.workspaceDir);
+        }
+        if (!deliverChannel && ctx.messageChannel && ctx.agentAccountId) {
+          const parts = ctx.messageChannel.split("|");
+          if (parts.length >= 2) {
+            deliverChannel = `${parts[0]}|${ctx.agentAccountId}|${parts.slice(1).join("|")}`;
+          }
+        }
+        if (!deliverChannel && ctx.messageChannel && ctx.messageChannel.includes("|")) {
+          deliverChannel = ctx.messageChannel;
+        }
+        if (!deliverChannel) {
+          deliverChannel = originChannel; // fallback to originChannel for backward compat
         }
 
         // --- Pre-launch safety guards ---
@@ -411,6 +430,7 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
           multiTurn: !params.multi_turn_disabled,
           permissionMode: params.permission_mode,
           originChannel,
+          deliverChannel,
           originAgentId: ctx.agentId || undefined,
         });
 

--- a/src/tools/claude-output.ts
+++ b/src/tools/claude-output.ts
@@ -2,7 +2,7 @@ import { Type } from "@sinclair/typebox";
 import { sessionManager, formatDuration } from "../shared";
 import type { OpenClawPluginToolContext } from "../types";
 
-export function makeClaudeOutputTool(_ctx?: OpenClawPluginToolContext) {
+export function makeClaudeOutputTool(ctx?: OpenClawPluginToolContext) {
   return {
     name: "claude_output",
     description: "Show recent output from a Claude Code session (by name or ID).",
@@ -31,7 +31,7 @@ export function makeClaudeOutputTool(_ctx?: OpenClawPluginToolContext) {
         };
       }
 
-      const session = sessionManager.resolve(params.session);
+      const session = sessionManager.resolve(params.session, ctx?.agentId);
 
       if (!session) {
         return {

--- a/src/tools/claude-respond.ts
+++ b/src/tools/claude-respond.ts
@@ -57,7 +57,7 @@ export function makeClaudeRespondTool(ctx?: OpenClawPluginToolContext) {
         };
       }
 
-      const session = sessionManager.resolve(params.session);
+      const session = sessionManager.resolve(params.session, ctx?.agentId);
 
       if (!session) {
         return {

--- a/src/tools/claude-sessions.ts
+++ b/src/tools/claude-sessions.ts
@@ -19,6 +19,13 @@ export function makeClaudeSessionsTool(ctx?: OpenClawPluginToolContext) {
           { description: 'Filter by status (default "all")' },
         ),
       ),
+      // Uncomment to allow agents to see all sessions across agents:
+      // scope: Type.Optional(
+      //   Type.Union(
+      //     [Type.Literal("mine"), Type.Literal("all")],
+      //     { description: 'Scope: "mine" (default) shows only this agent\'s sessions, "all" shows every session.' },
+      //   ),
+      // ),
     }),
     async execute(_id: string, params: any) {
       if (!sessionManager) {
@@ -35,21 +42,27 @@ export function makeClaudeSessionsTool(ctx?: OpenClawPluginToolContext) {
       const filter = params.status || "all";
       const allSessions = sessionManager.list(filter);
 
-      // Filter by agent's originChannel if context is available
+      // Filter by agent ownership (always applied when context is available).
+      // To re-enable scope: "all", uncomment the scope parameter above and use:
+      // const scope = params.scope || "mine";
+      // if (scope === "mine") { ... }
       let sessions = allSessions;
-      if (ctx?.workspaceDir) {
+      const agentId = ctx?.agentId;
+      if (agentId) {
+        // Primary: match by originAgentId
+        console.log(`[claude_sessions] Filtering sessions by agentId=${agentId}`);
+        sessions = allSessions.filter(s => s.originAgentId === agentId);
+      } else if (ctx?.workspaceDir) {
+        // Fallback: match by originChannel via workspace lookup
         const agentChannel = resolveAgentChannel(ctx.workspaceDir);
         if (agentChannel) {
           console.log(`[claude_sessions] Filtering sessions by agentChannel=${agentChannel}`);
-          sessions = allSessions.filter(s => {
-            const match = s.originChannel === agentChannel;
-            console.log(`[claude_sessions]   session=${s.id} originChannel=${s.originChannel} match=${match}`);
-            return match;
-          });
+          sessions = allSessions.filter(s => s.originChannel === agentChannel);
         } else {
           console.log(`[claude_sessions] No agentChannel found for workspaceDir=${ctx.workspaceDir}, returning all sessions`);
         }
       }
+      // If neither agentId nor workspaceDir: show all (backward compat for commands/gateway)
 
       if (sessions.length === 0) {
         return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface SessionConfig {
   systemPrompt?: string;
   allowedTools?: string[];
   originChannel?: string;  // Channel that spawned this session (for background notifications)
+  deliverChannel?: string; // Channel for --deliver args in wakeAgent() (resolved from launching agent's workspace)
   originAgentId?: string;  // Agent ID that launched this session (for targeted wake events)
   permissionMode?: PermissionMode;
 


### PR DESCRIPTION
## Changes

### Fix 1: Notification routing (closes #9)
- `originChannel` resolved from session workdir (for project context)
- `deliverChannel` resolved from agent workspace (for notifications + wake delivery)
- All Telegram notifications use `deliverChannel` — stays in launching agent's channel

### Fix 2: Session scoping
- `claude_sessions` filters by `originAgentId` — each agent sees only its own sessions
- No `scope: all` option (commented out in code for future use)

### Fix 3: Agent isolation in resolve()
- `SessionManager.resolve()` accepts optional `agentId` param
- All tools (kill, output, respond, fg, bg) pass `ctx.agentId`
- Agent can't access another agent's sessions

### Fix 4: Env var resolution in agentChannels keys
- `setPluginConfig()` expands `${VAR}` patterns in agentChannels keys
- Fixes gateway not resolving env vars in object keys

## Testing
- Session with cross-workspace workdir: notifications stay in launching agent's channel ✅
- Foreground streaming: routed to correct channel ✅
- Session filtering: agent only sees its own sessions ✅
- Env var resolution: `${HOME}` correctly expanded ✅