### PR TITLE
fix: resolve agentChannels from agent workspace, not session workdir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betrue/openclaw-claude-code-plugin",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "type": "commonjs",
   "main": "dist/index.js",
   "scripts": {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -127,7 +127,7 @@ export function resolveAgentId(workdir: string): string | undefined {
 }
 
 /**
- * Look up the notification channel for a given workdir from the agentChannels config.
+ * Look up the notification channel for a given agent workspace from the agentChannels config.
  * Normalises trailing slashes before comparison.
  * Returns undefined if no match is found.
  */
@@ -151,6 +151,15 @@ export function resolveAgentChannel(workdir: string): string | undefined {
     }
   }
   return undefined;
+}
+
+/**
+ * Check whether a session has a valid (non-"unknown") originChannel.
+ * Used to decide if we can fall back to the session's stored channel
+ * when resolveOriginChannel returns "unknown".
+ */
+export function hasValidOriginChannel(session: { originChannel?: string }): boolean {
+  return !!session.originChannel && session.originChannel !== "unknown";
 }
 
 export function formatDuration(ms: number): string {

--- a/src/tools/claude-bg.ts
+++ b/src/tools/claude-bg.ts
@@ -62,11 +62,10 @@ export function makeClaudeBgTool(ctx?: OpenClawPluginToolContext) {
 
         let channelId = resolveOriginChannel({ id: _id }, fallbackChannel);
         console.log(`[claude-bg] channelId resolved: ${channelId}, session.workdir=${session.workdir}`);
-        if (channelId === "unknown") {
-          const agentChannel = resolveAgentChannel(session.workdir);
-          if (agentChannel) {
-            channelId = agentChannel;
-          }
+        // Use the session's stored originChannel (resolved from the agent's workspace
+        // at creation time) instead of re-resolving from session.workdir.
+        if (channelId === "unknown" && session.originChannel && session.originChannel !== "unknown") {
+          channelId = session.originChannel;
         }
         session.saveFgOutputOffset(channelId);
         session.foregroundChannels.delete(channelId);
@@ -84,12 +83,12 @@ export function makeClaudeBgTool(ctx?: OpenClawPluginToolContext) {
       let resolvedId = resolveOriginChannel({ id: _id }, fallbackChannel);
       console.log(`[claude-bg] resolvedId (no session): ${resolvedId}`);
       if (resolvedId === "unknown") {
-        // Try each session's workdir to find a matching agent channel
+        // Try each session's stored originChannel (resolved from the agent's workspace
+        // at creation time) to find one with a matching foreground channel.
         const allSessionsForLookup = sessionManager.list("all");
         for (const s of allSessionsForLookup) {
-          const agentChannel = resolveAgentChannel(s.workdir);
-          if (agentChannel && s.foregroundChannels.has(agentChannel)) {
-            resolvedId = agentChannel;
+          if (s.originChannel && s.originChannel !== "unknown" && s.foregroundChannels.has(s.originChannel)) {
+            resolvedId = s.originChannel;
             break;
           }
         }

--- a/src/tools/claude-bg.ts
+++ b/src/tools/claude-bg.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { sessionManager, resolveOriginChannel, resolveAgentChannel } from "../shared";
+import { sessionManager, resolveOriginChannel, resolveAgentChannel, hasValidOriginChannel } from "../shared";
 import type { OpenClawPluginToolContext } from "../types";
 
 export function makeClaudeBgTool(ctx?: OpenClawPluginToolContext) {
@@ -64,7 +64,7 @@ export function makeClaudeBgTool(ctx?: OpenClawPluginToolContext) {
         console.log(`[claude-bg] channelId resolved: ${channelId}, session.workdir=${session.workdir}`);
         // Use the session's stored originChannel (resolved from the agent's workspace
         // at creation time) instead of re-resolving from session.workdir.
-        if (channelId === "unknown" && session.originChannel && session.originChannel !== "unknown") {
+        if (channelId === "unknown" && hasValidOriginChannel(session)) {
           channelId = session.originChannel;
         }
         session.saveFgOutputOffset(channelId);
@@ -87,7 +87,7 @@ export function makeClaudeBgTool(ctx?: OpenClawPluginToolContext) {
         // at creation time) to find one with a matching foreground channel.
         const allSessionsForLookup = sessionManager.list("all");
         for (const s of allSessionsForLookup) {
-          if (s.originChannel && s.originChannel !== "unknown" && s.foregroundChannels.has(s.originChannel)) {
+          if (hasValidOriginChannel(s) && s.foregroundChannels.has(s.originChannel!)) {
             resolvedId = s.originChannel;
             break;
           }

--- a/src/tools/claude-fg.ts
+++ b/src/tools/claude-fg.ts
@@ -66,12 +66,12 @@ export function makeClaudeFgTool(ctx?: OpenClawPluginToolContext) {
       console.log(`[claude-fg] channelId resolved: ${channelId}, session.workdir=${session.workdir}`);
 
       // If resolveOriginChannel couldn't determine a real channel (returned "unknown"),
-      // try resolving via the session's workdir → agentChannels mapping as a fallback.
-      if (channelId === "unknown") {
-        const agentChannel = resolveAgentChannel(session.workdir);
-        if (agentChannel) {
-          channelId = agentChannel;
-        }
+      // use the session's stored originChannel (resolved from the agent's workspace at
+      // creation time). This avoids re-resolving from session.workdir, which may not
+      // match any agentChannels entry (the session workdir is where Claude Code runs,
+      // not necessarily the agent's workspace).
+      if (channelId === "unknown" && session.originChannel && session.originChannel !== "unknown") {
+        channelId = session.originChannel;
       }
 
       // Get catchup output (produced while this channel was backgrounded)

--- a/src/tools/claude-fg.ts
+++ b/src/tools/claude-fg.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { sessionManager, formatDuration, resolveOriginChannel, resolveAgentChannel } from "../shared";
+import { sessionManager, formatDuration, resolveOriginChannel, resolveAgentChannel, hasValidOriginChannel } from "../shared";
 import type { OpenClawPluginToolContext } from "../types";
 
 export function makeClaudeFgTool(ctx?: OpenClawPluginToolContext) {
@@ -70,7 +70,7 @@ export function makeClaudeFgTool(ctx?: OpenClawPluginToolContext) {
       // creation time). This avoids re-resolving from session.workdir, which may not
       // match any agentChannels entry (the session workdir is where Claude Code runs,
       // not necessarily the agent's workspace).
-      if (channelId === "unknown" && session.originChannel && session.originChannel !== "unknown") {
+      if (channelId === "unknown" && hasValidOriginChannel(session)) {
         channelId = session.originChannel;
       }
 

--- a/src/tools/claude-launch.ts
+++ b/src/tools/claude-launch.ts
@@ -162,10 +162,32 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
 
         // --- Pre-launch safety guards ---
         // All guards can be skipped via pluginConfig.skipSafetyChecks for dev/testing.
-        const agentWorkspace = ctx.workspaceDir || workdir;
+        // We use ctx.workspaceDir (the agent's own workspace) — NOT workdir (the session's
+        // working directory). No agent workspace = no launch: we block rather than falling
+        // back to workdir, which would create a session with broken routing.
+        const agentWorkspace = ctx.workspaceDir;
 
         if (pluginConfig.skipSafetyChecks) {
           console.log(`[claude-launch] Safety checks skipped (skipSafetyChecks=true)`);
+        } else if (!agentWorkspace) {
+          console.log(`[claude-launch] No agent workspace detected (ctx.workspaceDir is undefined) — blocking launch`);
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: [
+                  `ERROR: Launch blocked — no agent workspace detected.`,
+                  ``,
+                  `ctx.workspaceDir is undefined, so safety guards and channel routing`,
+                  `cannot resolve the agent's workspace. This usually means the tool was`,
+                  `invoked outside an agent context.`,
+                  ``,
+                  `Ensure the agent has a configured workspaceDir before launching sessions.`,
+                ].join("\n"),
+              },
+            ],
+          };
         } else {
           // Guard: require autonomy skill in the agent's workspace before spawning.
           // The skill defines how the agent should handle Claude Code interactions
@@ -383,23 +405,24 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
           // channels so Claude Code sessions can route notifications to the correct agent/chat.
           // We check ctx.workspaceDir (the agent's own workspace), NOT the session's workdir
           // (which is just where Claude Code will work — it may be a different project).
-          const agentChannelForWorkspace = resolveAgentChannel(agentWorkspace);
+          const agentChannelForWorkspace = agentWorkspace ? resolveAgentChannel(agentWorkspace) : undefined;
           if (!agentChannelForWorkspace) {
-            console.log(`[claude-launch] No agentChannels mapping for agent workspace "${agentWorkspace}" — blocking launch`);
+            const displayPath = ctx.workspaceDir || workdir;
+            console.log(`[claude-launch] No agentChannels mapping for agent workspace "${displayPath}" — blocking launch`);
             return {
               isError: true,
               content: [
                 {
                   type: "text",
                   text: [
-                    `ERROR: Launch blocked — no agentChannels mapping found for agent workspace "${agentWorkspace}".`,
+                    `ERROR: Launch blocked — no agentChannels mapping found for agent workspace "${displayPath}".`,
                     ``,
                     `The agentChannels config maps agent workspaces to notification channels.`,
                     `Your agent workspace must be configured so notifications can be routed correctly.`,
                     ``,
                     `Add your agent workspace to agentChannels in ~/.openclaw/openclaw.json:`,
                     ``,
-                    `   plugins.entries["openclaw-claude-code-plugin"].config.agentChannels["${agentWorkspace}"] = "telegram|accountId|chatId"`,
+                    `   plugins.entries["openclaw-claude-code-plugin"].config.agentChannels["${displayPath}"] = "telegram|accountId|chatId"`,
                     ``,
                     `Then restart the Gateway and retry the launch.`,
                   ].join("\n"),

--- a/src/tools/claude-launch.ts
+++ b/src/tools/claude-launch.ts
@@ -106,22 +106,23 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
         }
 
         // Build originChannel with fallback chain:
-        // 1) resolveAgentChannel(workdir)        — the SESSION's workdir (most specific)
-        // 2) resolveAgentChannel(ctx.workspaceDir) — the AGENT's workspace
-        // 3) ctx.messageChannel with injected accountId
-        // 4) ctx.messageChannel as-is (if it already has |)
-        // 5) pluginConfig.fallbackChannel
+        // 1) resolveAgentChannel(ctx.workspaceDir) — the AGENT's workspace (authoritative)
+        // 2) ctx.messageChannel with injected accountId
+        // 3) ctx.messageChannel as-is (if it already has |)
+        // 4) pluginConfig.fallbackChannel
+        //
+        // NOTE: We resolve from the AGENT's workspace (ctx.workspaceDir), not the
+        // session's workdir. agentChannels maps agent workspaces (e.g. ~/clawd) to
+        // notification channels. The session workdir is just where Claude Code runs
+        // (e.g. /Users/selim/workspace/some-project) — it's not who requested the work.
         let originChannel: string | undefined;
 
-        // Tier 1: session workdir → agentChannels
-        originChannel = resolveAgentChannel(workdir);
-
-        // Tier 2: agent workspace → agentChannels
-        if (!originChannel && ctx.workspaceDir) {
+        // Tier 1: agent workspace → agentChannels (authoritative)
+        if (ctx.workspaceDir) {
           originChannel = resolveAgentChannel(ctx.workspaceDir);
         }
 
-        // Tier 3: ctx.messageChannel with injected accountId
+        // Tier 2: ctx.messageChannel with injected accountId
         if (!originChannel && ctx.messageChannel && ctx.agentAccountId) {
           const parts = ctx.messageChannel.split("|");
           if (parts.length >= 2) {
@@ -129,12 +130,12 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
           }
         }
 
-        // Tier 4: ctx.messageChannel as-is (if multi-segment)
+        // Tier 3: ctx.messageChannel as-is (if multi-segment)
         if (!originChannel && ctx.messageChannel && ctx.messageChannel.includes("|")) {
           originChannel = ctx.messageChannel;
         }
 
-        // Tier 5: pluginConfig.fallbackChannel
+        // Tier 4: pluginConfig.fallbackChannel
         if (!originChannel) {
           originChannel = pluginConfig.fallbackChannel ?? "unknown";
         }
@@ -377,39 +378,30 @@ export function makeClaudeLaunchTool(ctx: OpenClawPluginToolContext) {
             };
           }
 
-          // Guard: require agentChannels mapping for the workspace directory.
-          // The agentChannels config maps workspace directories to notification channels
-          // so Claude Code sessions can route notifications to the correct agent/chat.
-          // Without a mapping, notifications won't reach the right destination.
-          const agentChannelForWorkdir = resolveAgentChannel(workdir);
-          if (!agentChannelForWorkdir) {
-            console.log(`[claude-launch] No agentChannels mapping for workdir "${workdir}" — blocking launch`);
+          // Guard: require agentChannels mapping for the AGENT's workspace directory.
+          // The agentChannels config maps agent workspaces (e.g. ~/clawd) to notification
+          // channels so Claude Code sessions can route notifications to the correct agent/chat.
+          // We check ctx.workspaceDir (the agent's own workspace), NOT the session's workdir
+          // (which is just where Claude Code will work — it may be a different project).
+          const agentChannelForWorkspace = resolveAgentChannel(agentWorkspace);
+          if (!agentChannelForWorkspace) {
+            console.log(`[claude-launch] No agentChannels mapping for agent workspace "${agentWorkspace}" — blocking launch`);
             return {
               isError: true,
               content: [
                 {
                   type: "text",
                   text: [
-                    `ERROR: Launch blocked — no agentChannels mapping found for workspace "${workdir}".`,
+                    `ERROR: Launch blocked — no agentChannels mapping found for agent workspace "${agentWorkspace}".`,
                     ``,
-                    `Claude Code sessions require the workspace directory to be mapped in the agentChannels config`,
-                    `so notifications can be routed to the correct agent and chat.`,
+                    `The agentChannels config maps agent workspaces to notification channels.`,
+                    `Your agent workspace must be configured so notifications can be routed correctly.`,
                     ``,
-                    `You must add the workspace to agentChannels FIRST. Here's what to do:`,
+                    `Add your agent workspace to agentChannels in ~/.openclaw/openclaw.json:`,
                     ``,
-                    `1. Edit ~/.openclaw/openclaw.json and add the workspace mapping under plugins.entries["openclaw-claude-code-plugin"].config.agentChannels:`,
+                    `   plugins.entries["openclaw-claude-code-plugin"].config.agentChannels["${agentWorkspace}"] = "telegram|accountId|chatId"`,
                     ``,
-                    `   jq '.plugins.entries["openclaw-claude-code-plugin"].config.agentChannels["${workdir}"] = "channel|accountId|chatId"' ~/.openclaw/openclaw.json > /tmp/openclaw-updated.json && mv /tmp/openclaw-updated.json ~/.openclaw/openclaw.json`,
-                    ``,
-                    `   Replace "channel|accountId|chatId" with the actual values, e.g.: "telegram|my-agent|123456789"`,
-                    ``,
-                    `2. Verify the config was applied:`,
-                    ``,
-                    `   cat ~/.openclaw/openclaw.json | jq '.plugins.entries["openclaw-claude-code-plugin"].config.agentChannels'`,
-                    ``,
-                    `3. Restart the Gateway to pick up the new config, then retry the launch:`,
-                    ``,
-                    `   openclaw gateway restart`,
+                    `Then restart the Gateway and retry the launch.`,
                   ].join("\n"),
                 },
               ],

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,7 +97,7 @@ export interface PluginConfig {
   /**
    * Map of agent working directories to notification channels.
    * When a tool call (e.g. claude_launch) cannot resolve the origin channel
-   * from context, it checks whether the session workdir matches a key here
+   * from context, it checks whether the agent workspace matches a key here
    * and uses the mapped channel for notifications.
    *
    * Example: { "/home/user/my-seo-agent": "telegram|123456789" }


### PR DESCRIPTION
## Problem

The `agentChannels` guard and notification routing resolved channels from the Claude Code session's `workdir` instead of the agent's `ctx.workspaceDir`. When an agent at `~/clawd` launched a session in a different project directory, the guard failed and instructed the agent to self-add the project path — causing config bloat (12 entries instead of 5).

## Changes

| File | Fix |
|------|-----|
| `claude-launch.ts` | Guard + originChannel resolution use `ctx.workspaceDir` |
| `claude-fg.ts` | Fallback uses `session.originChannel` (already stored at creation) |
| `claude-bg.ts` | Same fix, 2 locations |

## Principle

`resolveAgentChannel()` utility unchanged. The fix is **what we pass to it**: always the agent's workspace, never the session's working directory. Downstream tools use `session.originChannel` directly.

Build passes ✅

Closes #12