### PR TITLE
Fix: Enable project skills loading via settingSources

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -167,6 +167,7 @@ export class Session {
         allowedTools: this.allowedTools,
         includePartialMessages: true,
         abortController: this.abortController,
+        settingSources: ["project", "user"] as const,
         ...(this.systemPrompt ? { systemPrompt: this.systemPrompt } : {}),
       };
 


### PR DESCRIPTION
## Problem

Claude Code sessions spawned by the plugin were not loading project-level skills (defined in `.claude/settings.json` or `.mcp.json`). Only user-level settings were being picked up.

## Root Cause

The `settingSources` option was not being passed to the Claude SDK's `startSession`, so it defaulted to user-only settings — skipping project-scoped skill definitions.

## Fix

Pass `settingSources: ["project", "user"]` in the session options so both project and user settings are loaded, enabling project skills to be discovered and used during sessions.

## Changes

- `src/session.ts`: Add `settingSources` to session creation options