### PR TITLE
fix: pin devDependency versions to exact semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "@anthropic-ai/claude-agent-sdk": "0.2.37"
   },
   "devDependencies": {
-    "esbuild": "^0.27.3",
-    "@sinclair/typebox": "^0.34.48",
-    "nanoid": "^3.3.7"
+    "esbuild": "0.27.3",
+    "@sinclair/typebox": "0.34.48",
+    "nanoid": "3.3.7"
   },
   "keywords": [
     "openclaw",


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: Three devDependencies use `^` semver ranges (`esbuild: ^0.27.3`, `@sinclair/typebox: ^0.34.48`, `nanoid: ^3.3.7`), allowing npm to pull in unvetted minor/patch releases on each `npm install`.

**Evidence**: `package.json` lines 24–26 contain `^`-prefixed versions; since `esbuild` drives the production bundle build, a compromised patch release would affect the published `dist/` artifact.

**Fix**: Remove the `^` prefix from all three devDependency versions, pinning each to its current exact version.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->